### PR TITLE
Fix README headings due to GitHub change

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Usage
 `XLData` supports different scenarios from in-memory to core data data sets, it is also able to synchronize the data set with the json results of an API endpoint. In this section we'll briefly explain how it can be used in typical scenarios. For a more detailed explanation please take a look at the [Examples](Examples) folder.
 
 
-####Data Store table/collection view controller
+#### Data Store table/collection view controller
 
 1 - Create a view controller object that extends from `XLDataStoreController`.
 
@@ -69,7 +69,7 @@ Any changes made to the data store will be automatically reflected in the table/
 For further details on how to implement this kind of view controller take a look at [UsersDataStoreController.m](/Examples/Controller/DataStore/UsersDataStoreController.m) file. You can see it in action by running the Demo app and tapping the cell "Data Store TableView" or "Data Store CollectionView".
 
 
-####Data Store table/collection view controller sync with remote json endpoint
+#### Data Store table/collection view controller sync with remote json endpoint
 
 1 - Create a view controller object that extends from `XLRemoteDataStoreController`.
 


### PR DESCRIPTION
GitHub changed its Markdown processor to stop supporting heading without spaces https://gist.github.com/vmarkovtsev/59cd7349d41cf804b9a8775388e681f8